### PR TITLE
feat: add backgroundComponent prop for custom toast backgrounds

### DIFF
--- a/docs/docs/Toaster.md
+++ b/docs/docs/Toaster.md
@@ -92,22 +92,74 @@ function Wrapper({toastId, children}){
 />;
 ```
 
+### Custom Background Component
+
+Use the `backgroundComponent` in `toastOptions` to add a custom background to all toasts, such as a blur effect. The background component will render inside the toast's animated view and participate in all animations.
+
+```tsx
+import { BlurView } from 'expo-blur';
+import { StyleSheet, Platform } from 'react-native';
+
+<Toaster
+  toastOptions={{
+    backgroundComponent: (
+      <BlurView
+        intensity={80}
+        tint="dark"
+        experimentalBlurMethod={
+          Platform.OS === 'android' ? 'dimezisBlurView' : undefined
+        }
+        style={StyleSheet.absoluteFill}
+      />
+    ),
+  }}
+/>;
+```
+
+**Important notes:**
+
+- The `backgroundComponent` must use `StyleSheet.absoluteFill` or equivalent absolute positioning
+- On Android, `expo-blur` requires `experimentalBlurMethod="dimezisBlurView"` for actual blur (otherwise falls back to semi-transparent view)
+- The library automatically applies `overflow: 'hidden'` and `backgroundColor: 'transparent'` when backgroundComponent is present
+- The background participates in all toast animations (enter, exit, wiggle)
+- Does not apply to custom JSX toasts (`toast.custom()`)
+
+You can also override the background on a per-toast basis using the `backgroundComponent` option in `toast()`:
+
+```tsx
+import { toast } from 'sonner-native';
+
+toast.success('Saved!', {
+  backgroundComponent: (
+    <BlurView
+      intensity={100}
+      tint="light"
+      experimentalBlurMethod={
+        Platform.OS === 'android' ? 'dimezisBlurView' : undefined
+      }
+      style={StyleSheet.absoluteFill}
+    />
+  ),
+});
+```
+
 ## API Reference
 
-| Property                  |                                            Description                                             |      Default |
-| :------------------------ | :------------------------------------------------------------------------------------------------: | -----------: |
-| theme                     |                                          `light`, `dark`                                           |     `system` |
-| visibleToasts             |                                  Maximum number of visible toasts                                  |          `3` |
-| position                  |                              Place where the toasts will be rendered                               | `top-center` |
-| offset                    |                                   Offset from the top or bottom                                    |          `0` |
-| closeButton               |                                 Adds a close button to all toasts                                  |      `false` |
-| invert                    |                             Dark toasts in light mode and vice versa.                              |      `false` |
-| toastOptions              | These will act as default options for all toasts. See [toast()](/toast) for all available options. |         `{}` |
-| gap                       |                                  Gap between toasts when expanded                                  |         `16` |
-| icons                     |                                     Changes the default icons                                      |          `-` |
-| pauseWhenPageIsHidden     |                        Pauses toast timers when the app enters background.                         |         `{}` |
-| `swipeToDismissDirection` |                             Swipe direction to dismiss (`left`, `up`).                             |         `up` |
-| ToasterOverlayWrapper     |                                Custom component to wrap the Toaster.                               |        `div` |
-| ToastWrapper              |                                Custom component to wrap the Toast.                                 |        `div` |
-| autoWiggleOnUpdate        |             Adds a wiggle animation on toast update. `never`, `toast-change`, `always`             |      `never` |
-| richColors                |                             Makes error and success state more colorful                            |      `false` |
+| Property                         |                                            Description                                             |      Default |
+| :------------------------------- | :------------------------------------------------------------------------------------------------: | -----------: |
+| theme                            |                                          `light`, `dark`                                           |     `system` |
+| visibleToasts                    |                                  Maximum number of visible toasts                                  |          `3` |
+| position                         |                              Place where the toasts will be rendered                               | `top-center` |
+| offset                           |                                   Offset from the top or bottom                                    |          `0` |
+| closeButton                      |                                 Adds a close button to all toasts                                  |      `false` |
+| invert                           |                             Dark toasts in light mode and vice versa.                              |      `false` |
+| toastOptions                     | These will act as default options for all toasts. See [toast()](/toast) for all available options. |         `{}` |
+| toastOptions.backgroundComponent |           Custom component rendered as toast background. Must use absolute positioning.            |          `-` |
+| gap                              |                                  Gap between toasts when expanded                                  |         `16` |
+| icons                            |                                     Changes the default icons                                      |          `-` |
+| pauseWhenPageIsHidden            |                        Pauses toast timers when the app enters background.                         |         `{}` |
+| `swipeToDismissDirection`        |                             Swipe direction to dismiss (`left`, `up`).                             |         `up` |
+| ToasterOverlayWrapper            |                                Custom component to wrap the Toaster.                               |        `div` |
+| ToastWrapper                     |                                 Custom component to wrap the Toast.                                |        `div` |
+| autoWiggleOnUpdate               |             Adds a wiggle animation on toast update. `never`, `toast-change`, `always`             |      `never` |
+| richColors                       |                             Makes error and success state more colorful                            |      `false` |

--- a/docs/docs/toast.md
+++ b/docs/docs/toast.md
@@ -222,7 +222,8 @@ Toasts can also be automatically wiggled by passing the `autoWiggleOnUpdate` pro
 | actionButtonTextStyles |                                   Styles for the action button text                                    |         `{}` |
 | cancelButtonStyles     |                                      Styles for the cancel button                                      |         `{}` |
 | cancelButtonTextStyles |                                   Styles for the cancel button text                                    |         `{}` |
-| richColors             |                               Makes error and success state more colorful                              |      `false` |
+| richColors             |                              Makes error and success state more colorful                               |      `false` |
+| backgroundComponent    |               Custom component rendered as toast background. Overrides Toaster default.                |          `-` |
 
 ```
 

--- a/example/package.json
+++ b/example/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/native": "^6.0.8",
     "@react-navigation/native-stack": "^6.9.12",
     "expo": "~51.0.32",
+    "expo-blur": "^15.0.7",
     "expo-status-bar": "~1.12.1",
     "nativewind": "4.1.6",
     "react": "18.2.0",

--- a/example/src/ToastDemo.tsx
+++ b/example/src/ToastDemo.tsx
@@ -459,6 +459,28 @@ export const ToastDemo: React.FC = () => {
           });
         }}
       />
+
+      <Button
+        title="Toast with BlurView background"
+        onPress={() => {
+          const { BlurView } = require('expo-blur');
+          const { StyleSheet, Platform } = require('react-native');
+
+          toast.success('Blur Background', {
+            description: 'This toast has a blur background',
+            backgroundComponent: (
+              <BlurView
+                intensity={20}
+                tint="dark"
+                experimentalBlurMethod={
+                  Platform.OS === 'android' ? 'dimezisBlurView' : undefined
+                }
+                style={StyleSheet.absoluteFill}
+              />
+            ),
+          });
+        }}
+      />
     </ScrollView>
   );
 };

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -45,6 +45,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
       invert: invertProps,
       richColors: richColorsProps,
       onPress,
+      backgroundComponent: backgroundComponentProps,
     },
     ref
   ) => {
@@ -70,6 +71,7 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
         buttonsStyle: buttonsStyleCtx,
         closeButtonStyle: closeButtonStyleCtx,
         closeButtonIconStyle: closeButtonIconStyleCtx,
+        backgroundComponent: backgroundComponentCtx,
       },
     } = useToastContext();
     const invert = invertProps ?? invertCtx;
@@ -77,6 +79,8 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
     const unstyled = unstyledProps ?? unstyledCtx;
     const duration = durationProps ?? durationCtx;
     const closeButton = closeButtonProps ?? closeButtonCtx;
+    const backgroundComponent =
+      backgroundComponentProps ?? backgroundComponentCtx;
 
     const { entering, exiting } = useToastLayoutAnimations(position);
 
@@ -344,6 +348,17 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
       );
     }
 
+    const backgroundComponentStyle = backgroundComponent
+      ? {
+          overflow: 'hidden' as const,
+          backgroundColor: 'transparent',
+        }
+      : undefined;
+
+    const contentContainerStyle = backgroundComponent
+      ? { position: 'relative' as const, zIndex: 1 }
+      : undefined;
+
     return (
       <ToastSwipeHandler {...toastSwipeHandlerProps}>
         <Animated.View style={wiggleAnimationStyle}>
@@ -354,15 +369,18 @@ export const Toast = React.forwardRef<ToastRef, ToastProps>(
               toastStyleCtx,
               styles?.toast,
               style,
+              backgroundComponentStyle,
             ]}
             entering={entering}
             exiting={exiting}
           >
+            {backgroundComponent}
             <View
               style={[
                 defaultStyles.toastContent,
                 toastContentStyleCtx,
                 styles?.toastContent,
+                contentContainerStyle,
               ]}
             >
               {promiseOptions || variant === 'loading' ? (

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ type StyleProps = {
     closeButton?: ViewStyle;
     closeButtonIcon?: ViewStyle;
   };
+  backgroundComponent?: React.ReactNode;
 };
 
 type PromiseOptions = {
@@ -110,6 +111,7 @@ export type ToasterProps = Omit<StyleProps, 'style'> & {
     buttonsStyle?: ViewStyle;
     closeButtonStyle?: ViewStyle;
     closeButtonIconStyle?: ViewStyle;
+    backgroundComponent?: React.ReactNode;
   };
   gap?: number;
   loadingIcon?: React.ReactNode;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9632,6 +9632,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-blur@npm:^15.0.7":
+  version: 15.0.7
+  resolution: "expo-blur@npm:15.0.7"
+  peerDependencies:
+    expo: "*"
+    react: "*"
+    react-native: "*"
+  checksum: 29aad1b3683fa96d86c1b568836eeffe2fca08f7202fd5a2a6c269f650d98b3ce1dbe4846d23efb00c94dfa7a5f2c4bbd6e0f6cc5ae3a1265e71464a9b46596e
+  languageName: node
+  linkType: hard
+
 "expo-constants@npm:~16.0.0":
   version: 16.0.2
   resolution: "expo-constants@npm:16.0.2"
@@ -19319,6 +19330,7 @@ __metadata:
     "@react-navigation/native": ^6.0.8
     "@react-navigation/native-stack": ^6.9.12
     expo: ~51.0.32
+    expo-blur: ^15.0.7
     expo-status-bar: ~1.12.1
     nativewind: 4.1.6
     react: 18.2.0


### PR DESCRIPTION
## Summary

This PR adds a new `backgroundComponent` prop that allows rendering custom background components (like BlurView) inside toasts.

### Motivation

On web, blur backgrounds can be achieved with CSS `backdrop-filter`. On React Native, this requires a component-based solution using libraries like `expo-blur` or `@react-native-community/blur`. The existing `ToastWrapper` prop doesn't work for this use case because it wraps outside the animated view, meaning backgrounds don't participate in animations or respect the toast's border radius.

This implementation renders the `backgroundComponent` inside the toast's animated view, ensuring proper animation participation and border radius clipping.

### Changes

**Type Definitions (`src/types.ts`)**

- Added `backgroundComponent?: React.ReactNode` to `StyleProps` interface (for per-toast usage)
- Added `backgroundComponent?: React.ReactNode` to `toastOptions` in `ToasterProps` (for global default)

**Toast Component (`src/toast.tsx`)**

- Renders background component inside the toast's `Animated.View`, before content
- Automatically applies `overflow: 'hidden'` and `backgroundColor: 'transparent'` when present
- Props-level `backgroundComponent` takes precedence over `toastOptions` default
- Does not render for custom JSX toasts (they have full control)

**Documentation**

- Updated `docs/docs/Toaster.md` with usage examples and important notes
- Updated `docs/docs/toast.md` API reference

**Example App**

- Installed `expo-blur@15.0.7`
- Added example demonstrating BlurView with proper platform-specific configuration

### Usage Example

```tsx
import { BlurView } from 'expo-blur';
import { Toaster, toast } from 'sonner-native';
import { StyleSheet, Platform } from 'react-native';

// Global default
<Toaster
  toastOptions={{
    backgroundComponent: (
      <BlurView
        intensity={80}
        tint="dark"
        experimentalBlurMethod={
          Platform.OS === 'android' ? 'dimezisBlurView' : undefined
        }
        style={StyleSheet.absoluteFill}
      />
    ),
  }}
/>;

// Per-toast override
toast.success('Saved!', {
  backgroundComponent: (
    <BlurView
      intensity={100}
      tint="light"
      experimentalBlurMethod={
        Platform.OS === 'android' ? 'dimezisBlurView' : undefined
      }
      style={StyleSheet.absoluteFill}
    />
  ),
});
```

**Breaking Changes:** None - purely additive feature

## Test plan

### Verification completed:

- ✅ `yarn typecheck` - No TypeScript errors
- ✅ `yarn lint` - No linting errors
- ✅ `yarn test` - All 8 tests pass
- ✅ `yarn prepare` - Builds successfully (commonjs, module, typescript)

### Manual testing:

1. Run the example app: `yarn example ios` or `yarn example android`
2. Tap "Toast with BlurView background"
3. Verify the toast displays with a blur background that:
   - Participates in enter/exit animations
   - Respects the toast's border radius
   - Works on both iOS and Android (Android requires `experimentalBlurMethod`)

### Testing without expo-blur:

The feature works with any React component. Test with a simple colored background:

```tsx
toast.success('Test', {
  backgroundComponent: (
    <View
      style={[
        StyleSheet.absoluteFill,
        { backgroundColor: 'rgba(100, 50, 200, 0.3)' },
      ]}
    />
  ),
});
```
