### PR TITLE
docs: warn against mounting more than one Toaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ export default function RootLayout() {
 
 This ensures the toasts will be displayed across all screens in your app.
 
+> **Note:** Mount exactly one `<Toaster />` per app. The toast store is a shared, module-level
+> singleton, so every mounted `<Toaster />` renders every `toast()` call. A second one - easy to
+> add by accident in a larger codebase, e.g. inside a separate internal package or provider that
+> isn't aware the host app already has one - will silently duplicate every toast instead of
+> erroring, which can be tricky to track down.
+
 ### Show a toast
 
 ```typescript


### PR DESCRIPTION
## Summary

Adds a short note to the README warning against mounting more than one `<Toaster />` per app.

## Why

While investigating what looked like a duplicate/ghost toast bug in #370, we eventually traced our specific repro to an app-level mistake, not a library bug: a second `<Toaster />` was mounted inside an internal shared package alongside the app's own top-level one. Since the toast store is a shared, module-level singleton, every mounted `<Toaster />` subscribes to and renders every `toast()` call - so this silently duplicated every toast instead of erroring or warning.

It's an easy trap in any codebase with independently-developed feature packages/providers, and the resulting symptom (toasts appearing to duplicate) looks confusingly similar to real animation/rendering bugs, so it's worth documenting explicitly rather than leaving it to be rediscovered by trial and error.

## Test plan

Docs-only change, no code paths affected.